### PR TITLE
#1 - Relax equality check for player instances

### DIFF
--- a/core/src/main/scala/scroll/internal/Compartment.scala
+++ b/core/src/main/scala/scroll/internal/Compartment.scala
@@ -8,10 +8,9 @@ import scroll.internal.support._
 import scroll.internal.util.ReflectiveHelper
 
 import scala.annotation.tailrec
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.{ ClassTag, classTag }
 
-/**
-  * This Trait allows for implementing an objectified collaboration with a limited number of participating roles and a fixed scope.
+/** This Trait allows for implementing an objectified collaboration with a limited number of participating roles and a fixed scope.
   *
   * ==Overview==
   * Roles are dependent on some sort of context. We call them compartments. A typical example of a compartment is a university,
@@ -35,11 +34,11 @@ import scala.reflect.{ClassTag, classTag}
   */
 trait Compartment
   extends RoleConstraints
-    with RoleRestrictions
-    with RoleGroups
-    with Relationships
-    with QueryStrategies
-    with RoleUnionTypes {
+  with RoleRestrictions
+  with RoleGroups
+  with Relationships
+  with QueryStrategies
+  with RoleUnionTypes {
 
   protected var plays: ScalaRoleGraph = new ScalaRoleGraph()
 
@@ -50,16 +49,14 @@ trait Compartment
       r
     })
 
-  /**
-    * Declaring a is-part-of relation between compartments.
+  /** Declaring a is-part-of relation between compartments.
     */
   def partOf(other: Compartment): Unit = {
     require(null != other)
     plays.merge(other.plays)
   }
 
-  /**
-    * Declaring a bidirectional is-part-of relation between compartment.
+  /** Declaring a bidirectional is-part-of relation between compartment.
     */
   def union(other: Compartment): Compartment = {
     require(null != other)
@@ -68,8 +65,7 @@ trait Compartment
     this
   }
 
-  /**
-    * Merge role graphs to this and set other role graph to this one.
+  /** Merge role graphs to this and set other role graph to this one.
     */
   def combine(other: Compartment): Compartment = {
     require(null != other)
@@ -80,22 +76,20 @@ trait Compartment
     this
   }
 
-  /**
-    * Removing is-part-of relation between compartments.
+  /** Removing is-part-of relation between compartments.
     */
   def notPartOf(other: Compartment): Unit = {
     require(null != other)
     plays.detach(other.plays)
   }
 
-  /**
-    * Query the role playing graph for all player instances that do conform to the given matcher.
+  /** Query the role playing graph for all player instances that do conform to the given matcher.
     *
     * @param matcher the matcher that should match the queried player instance in the role playing graph
     * @tparam T the type of the player instance to query for
     * @return all player instances as Seq, that do conform to the given matcher
     */
-  def all[T <: AnyRef : ClassTag](matcher: RoleQueryStrategy = MatchAny()): Seq[T] = {
+  def all[T <: AnyRef: ClassTag](matcher: RoleQueryStrategy = MatchAny()): Seq[T] = {
     plays.allPlayers.filter(ReflectiveHelper.is[T]).map(_.asInstanceOf[T]).filter(a => {
       getCoreFor(a) match {
         case p :: Nil => matcher.matches(p)
@@ -105,14 +99,13 @@ trait Compartment
     })
   }
 
-  /**
-    * Query the role playing graph for all player instances that do conform to the given function.
+  /** Query the role playing graph for all player instances that do conform to the given function.
     *
     * @param matcher the matching function that should match the queried player instance in the role playing graph
     * @tparam T the type of the player instance to query for
     * @return all player instances as Seq, that do conform to the given matcher
     */
-  def all[T <: AnyRef : ClassTag](matcher: T => Boolean): Seq[T] =
+  def all[T <: AnyRef: ClassTag](matcher: T => Boolean): Seq[T] =
     plays.allPlayers.filter(ReflectiveHelper.is[T]).map(_.asInstanceOf[T]).filter(a => {
       getCoreFor(a) match {
         case p :: Nil => matcher(p.asInstanceOf[T])
@@ -126,66 +119,60 @@ trait Compartment
     case s => Right(s)
   }
 
-  /**
-    * Query the role playing graph for all player instances that do conform to the given matcher and return the first found.
+  /** Query the role playing graph for all player instances that do conform to the given matcher and return the first found.
     *
     * @param matcher the matcher that should match the queried player instance in the role playing graph
     * @tparam T the type of the player instance to query for
     * @return the first player instance, that does conform to the given matcher or an appropriate error
     */
-  def one[T <: AnyRef : ClassTag](matcher: RoleQueryStrategy = MatchAny()): Either[TypeError, T] = safeReturn(all[T](matcher), classTag[T].toString).fold(
+  def one[T <: AnyRef: ClassTag](matcher: RoleQueryStrategy = MatchAny()): Either[TypeError, T] = safeReturn(all[T](matcher), classTag[T].toString).fold(
     l => {
       Left(l)
     }, r => {
       Right(r.head)
     })
 
-
-  /**
-    * Query the role playing graph for all player instances that do conform to the given function and return the first found.
+  /** Query the role playing graph for all player instances that do conform to the given function and return the first found.
     *
     * @param matcher the matching function that should match the queried player instance in the role playing graph
     * @tparam T the type of the player instance to query for
     * @return the first player instances, that do conform to the given matcher or an appropriate error
     */
-  def one[T <: AnyRef : ClassTag](matcher: T => Boolean): Either[TypeError, T] = safeReturn(all[T](matcher), classTag[T].toString).fold(
+  def one[T <: AnyRef: ClassTag](matcher: T => Boolean): Either[TypeError, T] = safeReturn(all[T](matcher), classTag[T].toString).fold(
     l => {
       Left(l)
     }, r => {
       Right(r.head)
     })
 
-  /**
-    * Adds a play relation between core and role.
+  /** Adds a play relation between core and role.
     *
     * @tparam C type of core
     * @tparam R type of role
     * @param core the core to add the given role at
     * @param role the role that should added to the given core
     */
-  def addPlaysRelation[C <: AnyRef : ClassTag, R <: AnyRef : ClassTag](core: C, role: R): Unit = {
+  def addPlaysRelation[C <: AnyRef: ClassTag, R <: AnyRef: ClassTag](core: C, role: R): Unit = {
     require(null != core)
     require(null != role)
     validate(core, role)
     plays.addBinding(core, role)
   }
 
-  /**
-    * Removes the play relation between core and role.
+  /** Removes the play relation between core and role.
     *
     * @tparam C type of core
     * @tparam R type of role
     * @param core the core the given role should removed from
     * @param role the role that should removed from the given core
     */
-  def removePlaysRelation[C <: AnyRef : ClassTag, R <: AnyRef : ClassTag](core: C, role: R): Unit = {
+  def removePlaysRelation[C <: AnyRef: ClassTag, R <: AnyRef: ClassTag](core: C, role: R): Unit = {
     require(null != core)
     require(null != role)
     plays.removeBinding(core, role)
   }
 
-  /**
-    * Transfers a role from one core to another.
+  /** Transfers a role from one core to another.
     *
     * @tparam F type of core the given role should be removed from
     * @tparam T type of core the given role should be attached to
@@ -194,7 +181,7 @@ trait Compartment
     * @param coreTo   the core the given role should be attached to
     * @param role     the role that should be transferred
     */
-  def transferRole[F <: AnyRef : ClassTag, T <: AnyRef : ClassTag, R <: AnyRef : ClassTag](coreFrom: F, coreTo: T, role: R): Unit = {
+  def transferRole[F <: AnyRef: ClassTag, T <: AnyRef: ClassTag, R <: AnyRef: ClassTag](coreFrom: F, coreTo: T, role: R): Unit = {
     require(null != coreFrom)
     require(null != coreTo)
     require(null != role)
@@ -214,7 +201,7 @@ trait Compartment
     * @tparam T the type of the object
     * @return the player
     */
-  def lift[T <: AnyRef : ClassTag](player: T): Option[Player[T]] = {
+  def lift[T <: AnyRef: ClassTag](player: T): Option[Player[T]] = {
     player match {
       case p: Player[_] if plays.containsPlayer(p.wrapped) => Some(p)
       case Player => None
@@ -231,7 +218,7 @@ trait Compartment
     * @tparam T the type of the object
     * @return the player
     */
-  def @:[T <: AnyRef : ClassTag](player: T): Option[Player[T]] = lift(player)
+  def @:[T <: AnyRef: ClassTag](player: T): Option[Player[T]] = lift(player)
 
   @tailrec
   protected final def getCoreFor(role: AnyRef): Seq[AnyRef] = {
@@ -253,8 +240,7 @@ trait Compartment
     }
   }
 
-  /**
-    * Explicit helper factory method for creating a new Player instance
+  /** Explicit helper factory method for creating a new Player instance
     * without the need to relying on the implicit mechanics of Scala.
     *
     * @param obj the player or role that is wrapped into this dynamic player type
@@ -265,12 +251,11 @@ trait Compartment
     new Player(obj)
   }
 
-  implicit class Player[T <: AnyRef : ClassTag](override val wrapped: T) extends IPlayer[T](wrapped) with SCROLLDynamic with SCROLLDispatchable {
+  implicit class Player[T <: AnyRef: ClassTag](override val wrapped: T) extends IPlayer[T](wrapped) with SCROLLDynamic with SCROLLDispatchable {
 
     override def unary_+ : Player[T] = this
 
-    /**
-      * Returns the player of this player instance if this is a role, or this itself.
+    /** Returns the player of this player instance if this is a role, or this itself.
       *
       * @param dispatchQuery provide this to sort the resulting instances if a role instance is played by multiple core objects
       * @return the player of this player instance if this is a role, or this itself or an appropriate error
@@ -281,7 +266,7 @@ trait Compartment
       case _ => Left(TypeNotFound(this.getClass.toString))
     }
 
-    override def play[R <: AnyRef : ClassTag](role: R): Player[T] = {
+    override def play[R <: AnyRef: ClassTag](role: R): Player[T] = {
       require(null != role)
       wrapped match {
         case p: Player[_] => addPlaysRelation[T, R](p.wrapped.asInstanceOf[T], role)
@@ -291,77 +276,70 @@ trait Compartment
       this
     }
 
-    override def <+>[R <: AnyRef : ClassTag](role: R): Player[T] = play(role)
+    override def <+>[R <: AnyRef: ClassTag](role: R): Player[T] = play(role)
 
-    /**
-      * Adds a play relation between core and role but always returns the player instance.
+    /** Adds a play relation between core and role but always returns the player instance.
       *
       * @tparam R type of role
       * @param role the role that should played
       * @return the player instance
       */
-    def playing[R <: AnyRef : ClassTag](role: R): T = play(role).wrapped
+    def playing[R <: AnyRef: ClassTag](role: R): T = play(role).wrapped
 
-    /**
-      * Alias for [[Player.playing]].
+    /** Alias for [[Player.playing]].
       *
       * @tparam R type of role
       * @param role the role that should played
       * @return the player instance
       */
-    def <=>[R <: AnyRef : ClassTag](role: R): T = playing(role)
+    def <=>[R <: AnyRef: ClassTag](role: R): T = playing(role)
 
-    override def drop[R <: AnyRef : ClassTag](role: R): Player[T] = {
+    override def drop[R <: AnyRef: ClassTag](role: R): Player[T] = {
       removePlaysRelation[T, R](wrapped, role)
       this
     }
 
-    override def <->[R <: AnyRef : ClassTag](role: R): Player[T] = drop(role)
+    override def <->[R <: AnyRef: ClassTag](role: R): Player[T] = drop(role)
 
     override def getRoles: Seq[AnyRef] = plays.getRoles(this)
 
-    /**
-      * Transfers a role to another player.
+    /** Transfers a role to another player.
       *
       * @tparam R type of role
       * @param role the role to transfer
       */
-    def transfer[R <: AnyRef : ClassTag](role: R) = new {
-      def to[P <: AnyRef : ClassTag](player: P): Unit = {
+    def transfer[R <: AnyRef: ClassTag](role: R) = new {
+      def to[P <: AnyRef: ClassTag](player: P): Unit = {
         transferRole[T, P, R](wrapped, player, role)
       }
     }
 
-    /**
-      * Checks of this Player is playing a role of the given type R.
+    /** Checks of this Player is playing a role of the given type R.
       *
       * @tparam R type of role
       * @return true if this player is playing a role of type R, false otherwise. Returns false also, if
       *         the player is not available in the role-playing graph.
       */
-    def isPlaying[R <: AnyRef : ClassTag]: Boolean = plays.getRoles(wrapped).exists(ReflectiveHelper.is[R])
+    def isPlaying[R <: AnyRef: ClassTag]: Boolean = plays.getRoles(wrapped).exists(ReflectiveHelper.is[R])
 
-    /**
-      * Checks if this Player has all of the given facet(s) attached.
+    /** Checks if this Player has all of the given facet(s) attached.
       *
       * @param f the facet(s)
       * @return true if this player has all of the given facets attached, false otherwise.
       */
     def hasFacets(f: Enumeration#Value*): Boolean = f.forall(plays.getFacets(wrapped).contains)
 
-    /**
-      * Checks if this Player has at least one of the given facets attached.
+    /** Checks if this Player has at least one of the given facets attached.
       *
       * @param f the facets
       * @return true if this player has at least one of the given facets attached, false otherwise.
       */
     def hasSomeFacet(f: Enumeration#Value*): Boolean = f.exists(plays.getFacets(wrapped).contains)
 
-    /**
-      * Checks of this Player has an extension of the given type.
+    /** Checks of this Player has an extension of the given type.
       * Alias for [[Player.isPlaying]].
       */
-    def hasExtension[E <: AnyRef : ClassTag]: Boolean = isPlaying[E]
+    def hasExtension[E <: AnyRef: ClassTag]: Boolean = isPlaying[E]
 
     override def applyDynamic[E, A](name: String)(args: A*)(implicit dispatchQuery: DispatchQuery = DispatchQuery.empty): Either[SCROLLError, E] = {
       val core = getCoreFor(wrapped).last
@@ -399,20 +377,22 @@ trait Compartment
     }
 
     override def equals(o: Any): Boolean = o match {
-      case other: Player[_] => getCoreFor(wrapped) == getCoreFor(other.wrapped)
-      case other: Any => getCoreFor(wrapped) match {
-        case Nil => false
-        case p :: Nil => p == other
-        case _ => false
-      }
+      case other: Player[_] =>
+        val ownCore = getCoreFor(wrapped)
+        val otherCore = getCoreFor(other.wrapped)
+        ownCore.reverse.headOption == otherCore.reverse.headOption
+      case other: Any => getCoreFor(wrapped).contains(other)
       case _ => false // default case
     }
 
     override def hashCode(): Int = wrapped.hashCode()
+
+    override def toString: String = s"${this.getClass.getName}: ${wrapped}"
+
   }
 
   object Player {
-    def unapply[T <: AnyRef : ClassTag](arg: Player[T]): Option[T] = Some(arg.wrapped)
+    def unapply[T <: AnyRef: ClassTag](arg: Player[T]): Option[T] = Some(arg.wrapped)
   }
 
 }


### PR DESCRIPTION
If equality with another player is to be checked, it will only compare the
directly preceding nodes (i.e. players or roles).

If equality with any other object should be checked, this object will
be looked up in the core of the player.

This solves #1.

_Most of the changes are just formatting due to inconsistent code styles. The real changes start at line 380_